### PR TITLE
Fix PHAR execution issues for v1.0.0

### DIFF
--- a/bin/mcp-server.php
+++ b/bin/mcp-server.php
@@ -10,6 +10,10 @@ $isPhar = ! file_exists($sourceAutoload);
 
 if ($isPhar) {
     Phar::mapPhar('php-composer-mcp.phar');
+    // Get the actual PHAR path for use in discovery
+    $pharPath = Phar::running(false);
+} else {
+    $pharPath = null;
 }
 
 define('VERSION', '__VERSION__');
@@ -55,7 +59,8 @@ try {
         ->build();
 
     // Discover MCP tools via attributes in the Tools directory
-    $basePath = $isPhar ? 'phar://php-composer-mcp.phar' : dirname(__DIR__);
+    // Use the full phar:// path when running from PHAR, or source directory otherwise
+    $basePath = $isPhar ? $pharPath : dirname(__DIR__);
     $server->discover(
         basePath: $basePath,
         scanDirs: ['src/Tools']


### PR DESCRIPTION
The discovery method requires the full `phar://` path, not just the relative `phar://php-composer-mcp.phar` path. Use `Phar::running(false)` to get the complete `phar://` URL which includes the actual filesystem path.

This fixes the error:
```
"Invalid discovery base path provided to discover(): phar://php-composer-mcp.phar"
```